### PR TITLE
Overwrite existing file, instead of broken append

### DIFF
--- a/Services/FolderService.cs
+++ b/Services/FolderService.cs
@@ -67,7 +67,7 @@ namespace Services
             var folder = await this._folderConfigService.GetFolderConfigByFolderName(folderName);
             var filePath = Path.Combine(folder.Path, fileName);
 
-            using (FileStream fs = new FileStream(filePath, FileMode.OpenOrCreate, FileAccess.ReadWrite))
+            using (FileStream fs = new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite))
             {
                 await file.CopyToAsync(fs);
             }


### PR DESCRIPTION
When a file already exists, the current method was appending / replacing, occasionally breaking a file. New method just overwrites the entire file instead of editting the contents